### PR TITLE
Configure SSR and scaffold base pages

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,15 @@
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
-  </div>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>
+
+<script setup lang="ts">
+useHead({
+  titleTemplate: (titleChunk) =>
+    titleChunk ? `${titleChunk} · Flowbite Nuxt` : 'Flowbite Nuxt',
+  htmlAttrs: {
+    lang: 'fr'
+  }
+})
+</script>

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,12 @@
+<template>
+  <main>
+    <h1>Une erreur est survenue</h1>
+    <button type="button" @click="handleNavigate">Revenir à l'accueil</button>
+  </main>
+</template>
+
+<script setup lang="ts">
+const handleNavigate = () => {
+  navigateTo('/')
+}
+</script>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,14 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  ssr: true,
+  build: {
+    transpile: ['flowbite-vue']
+  },
+  vite: {
+    ssr: {
+      noExternal: ['flowbite-vue']
+    }
+  }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <main>
+    <h1>Accueil</h1>
+  </main>
+</template>


### PR DESCRIPTION
## Summary
- enable SSR mode and configure Flowbite Vue transpilation for SSR builds
- scaffold the root app component with a basic head setup and Nuxt layout/page rendering
- add a home page and error page with navigation back to the index

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d62c18b164832f978247fd71723372