### PR TITLE
feat: add tenant middleware and theme tokens

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -5,11 +5,49 @@
 </template>
 
 <script setup lang="ts">
-useHead({
-  titleTemplate: (titleChunk) =>
+interface TenantHeadPayload {
+  id: string
+  theme: 'light' | 'dark'
+  css: string
+}
+
+const event = process.server ? useRequestEvent() : null
+const initialTenant = event?.context.tenant
+
+const tenantState = useState<TenantHeadPayload>('tenant', () => ({
+  id: initialTenant?.id ?? 'acme',
+  theme: initialTenant?.theme ?? 'light',
+  css: initialTenant?.css ?? ''
+}))
+
+if (process.server && initialTenant) {
+  tenantState.value = {
+    id: initialTenant.id,
+    theme: initialTenant.theme,
+    css: initialTenant.css
+  }
+}
+
+useHead(() => ({
+  titleTemplate: (titleChunk?: string) =>
     titleChunk ? `${titleChunk} · Flowbite Nuxt` : 'Flowbite Nuxt',
   htmlAttrs: {
-    lang: 'fr'
+    lang: 'fr',
+    'data-tenant': tenantState.value.id,
+    'data-theme': tenantState.value.theme
+  },
+  style: tenantState.value.css
+    ? [
+        {
+          id: 'tenant-tokens',
+          key: 'tenant-tokens',
+          innerHTML: tenantState.value.css,
+          tagPriority: 'critical'
+        }
+      ]
+    : [],
+  dangerouslyDisableSanitizersByTagID: {
+    'tenant-tokens': ['innerHTML']
   }
-})
+}))
 </script>

--- a/server/middleware/tenant.ts
+++ b/server/middleware/tenant.ts
@@ -1,0 +1,69 @@
+import { defineEventHandler, getHeader, getQuery } from 'h3'
+import {
+  DEFAULT_TENANT,
+  loadTokens,
+  tokensToCssVars,
+  type ThemeMode
+} from '../utils/theme'
+
+const SUPPORTED_TENANTS = new Set(['acme', 'beta', 'gamma'])
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const queryTenant = normalizeTenant(query.tenant)
+  const hostTenant = normalizeTenantFromHost(
+    getHeader(event, 'x-forwarded-host') ?? getHeader(event, 'host')
+  )
+
+  const tenantId = queryTenant ?? hostTenant ?? DEFAULT_TENANT
+  const tokens = await loadTokens(tenantId)
+  const css = tokensToCssVars(tokens)
+  const theme = normalizeTheme(tokens.meta.defaultTheme)
+
+  event.context.tenant = {
+    id: tenantId,
+    theme,
+    tokens,
+    css
+  }
+})
+
+function normalizeTenant(input: unknown): string | null {
+  if (Array.isArray(input)) {
+    return normalizeTenant(input[0])
+  }
+
+  if (typeof input !== 'string') {
+    return null
+  }
+
+  const candidate = input.trim().toLowerCase()
+  return SUPPORTED_TENANTS.has(candidate) ? candidate : null
+}
+
+function normalizeTenantFromHost(headerValue: string | null | undefined): string | null {
+  if (!headerValue) {
+    return null
+  }
+
+  const [firstHost] = headerValue.split(',')
+  if (!firstHost) {
+    return null
+  }
+
+  const hostname = firstHost.trim().split(':')[0]?.toLowerCase()
+  if (!hostname) {
+    return null
+  }
+
+  if (SUPPORTED_TENANTS.has(hostname)) {
+    return hostname
+  }
+
+  const [subdomain] = hostname.split('.')
+  return subdomain && SUPPORTED_TENANTS.has(subdomain) ? subdomain : null
+}
+
+function normalizeTheme(theme: ThemeMode): ThemeMode {
+  return theme === 'dark' ? 'dark' : 'light'
+}

--- a/server/tokens/acme.json
+++ b/server/tokens/acme.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "defaultTheme": "light",
+    "label": "Acme"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#ffffff",
+      "--color-foreground": "#0f172a",
+      "--accent-color": "#2563eb"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#0f172a",
+      "--color-foreground": "#f8fafc",
+      "--accent-color": "#60a5fa"
+    }
+  }
+}

--- a/server/tokens/beta.json
+++ b/server/tokens/beta.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "defaultTheme": "light",
+    "label": "Beta"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#f1f5f9",
+      "--color-foreground": "#1f2937",
+      "--accent-color": "#0ea5e9"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#0f172a",
+      "--color-foreground": "#e2e8f0",
+      "--accent-color": "#38bdf8"
+    }
+  }
+}

--- a/server/tokens/gamma.json
+++ b/server/tokens/gamma.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "defaultTheme": "dark",
+    "label": "Gamma"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#e5e7eb",
+      "--color-foreground": "#111827",
+      "--accent-color": "#9333ea"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#111827",
+      "--color-foreground": "#e5e7eb",
+      "--accent-color": "#a855f7"
+    }
+  }
+}

--- a/server/utils/theme.ts
+++ b/server/utils/theme.ts
@@ -1,0 +1,103 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const DEFAULT_TENANT = 'acme'
+export type ThemeMode = 'light' | 'dark'
+
+const TOKENS_DIRECTORY = join(process.cwd(), 'server', 'tokens')
+
+export interface ThemeVariant {
+  vars: Record<string, string>
+}
+
+export interface DarkThemeVariant extends ThemeVariant {
+  enabled: boolean
+}
+
+export interface TenantTokenMeta {
+  defaultTheme: ThemeMode
+  label?: string
+}
+
+export interface TenantTokens {
+  meta: TenantTokenMeta
+  light: ThemeVariant
+  dark?: DarkThemeVariant
+}
+
+export async function loadTokens(tenant: string): Promise<TenantTokens> {
+  const filePath = join(TOKENS_DIRECTORY, `${tenant}.json`)
+
+  try {
+    const source = await readFile(filePath, 'utf8')
+    const parsed = JSON.parse(source) as Record<string, unknown>
+    return normalizeTokens(parsed)
+  } catch (error) {
+    if (tenant !== DEFAULT_TENANT) {
+      return loadTokens(DEFAULT_TENANT)
+    }
+
+    throw error
+  }
+}
+
+export function tokensToCssVars(tokens: TenantTokens): string {
+  const cssBlocks: string[] = []
+  const lightVars = serializeVars(tokens.light.vars)
+
+  cssBlocks.push(`:root{${lightVars}}`)
+
+  if (tokens.dark?.enabled && Object.keys(tokens.dark.vars).length > 0) {
+    cssBlocks.push(`:root[data-theme="dark"]{${serializeVars(tokens.dark.vars)}}`)
+  }
+
+  return cssBlocks.join('\n')
+}
+
+function normalizeTokens(raw: Record<string, unknown>): TenantTokens {
+  const metaSource = (raw.meta ?? {}) as Record<string, unknown>
+  const lightSource = (raw.light ?? {}) as Record<string, unknown>
+  const darkSource = (raw.dark ?? {}) as Record<string, unknown>
+
+  const defaultTheme = metaSource.defaultTheme === 'dark' ? 'dark' : 'light'
+  const lightVars = extractVars(lightSource.vars)
+  const darkVars = extractVars(darkSource.vars)
+  const darkEnabled = Boolean(darkSource.enabled)
+
+  const tokens: TenantTokens = {
+    meta: {
+      defaultTheme,
+      label: typeof metaSource.label === 'string' ? metaSource.label : undefined
+    },
+    light: {
+      vars: lightVars
+    }
+  }
+
+  if (darkEnabled) {
+    tokens.dark = {
+      enabled: true,
+      vars: darkVars
+    }
+  }
+
+  return tokens
+}
+
+function extractVars(source: unknown): Record<string, string> {
+  if (!source || typeof source !== 'object') {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(source as Record<string, unknown>).flatMap(([key, value]) =>
+      typeof value === 'string' ? [[key, value]] : []
+    )
+  )
+}
+
+function serializeVars(variables: Record<string, string>): string {
+  return Object.entries(variables)
+    .map(([token, value]) => `${token}:${value};`)
+    .join('')
+}

--- a/types/tenant.d.ts
+++ b/types/tenant.d.ts
@@ -1,0 +1,12 @@
+import type { ThemeMode, TenantTokens } from '../server/utils/theme'
+
+declare module 'h3' {
+  interface H3EventContext {
+    tenant?: {
+      id: string
+      theme: ThemeMode
+      tokens: TenantTokens
+      css: string
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a server middleware to resolve the active tenant from headers or query parameters and load theme tokens
- provide utilities and token files to serialize tenant themes into CSS variables
- inject tenant-specific CSS variables and attributes into the app head for SSR hydration

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d62d3a2620832fb1acdd0495dbed57