### PR TITLE
Add tenant token definitions

### DIFF
--- a/tokens/acme.tokens.json
+++ b/tokens/acme.tokens.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "label": "Acme",
+    "defaultTheme": "light"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#ffffff",
+      "--color-foreground": "#0f172a",
+      "--accent-color": "#2563eb"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#0f172a",
+      "--color-foreground": "#f8fafc",
+      "--accent-color": "#60a5fa"
+    }
+  }
+}

--- a/tokens/beta.tokens.json
+++ b/tokens/beta.tokens.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "label": "Beta",
+    "defaultTheme": "dark"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#ede9fe",
+      "--color-foreground": "#1f2937",
+      "--accent-color": "#7c3aed"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#1e1b4b",
+      "--color-foreground": "#ede9fe",
+      "--accent-color": "#a855f7"
+    }
+  }
+}

--- a/tokens/gamma.tokens.json
+++ b/tokens/gamma.tokens.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "label": "Gamma",
+    "defaultTheme": "light"
+  },
+  "light": {
+    "vars": {
+      "--color-background": "#f0fdf4",
+      "--color-foreground": "#064e3b",
+      "--accent-color": "#22c55e"
+    }
+  },
+  "dark": {
+    "enabled": true,
+    "vars": {
+      "--color-background": "#064e3b",
+      "--color-foreground": "#dcfce7",
+      "--accent-color": "#4ade80"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Acme design tokens with blue theme defaults
- define Beta violet theme tokens emphasizing dark backgrounds
- introduce Gamma light green theme tokens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62f72cb64832fac93d2d5cf3ccb28