### PR TITLE
feat: configure tailwindcss and flowbite integration

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,0 +1,9 @@
+@import "tailwindcss";
+@plugin "flowbite/plugin";
+@source "./components";
+@source "./pages";
+@source "./layouts";
+@source "./app.vue";
+@source "./error.vue";
+@source "../node_modules/flowbite";
+@source "../node_modules/flowbite-vue";

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,7 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   ssr: true,
+  css: ['../assets/css/tailwind.css'],
   build: {
     transpile: ['flowbite-vue']
   },

--- a/plugins/flowbite.client.ts
+++ b/plugins/flowbite.client.ts
@@ -1,0 +1,6 @@
+import Flowbite from 'flowbite-vue';
+import 'flowbite-vue/index.css';
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(Flowbite);
+});

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+
+export default {
+  plugins: [tailwindcss, autoprefixer],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,51 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './app.vue',
+    './error.vue',
+    './app/**/*.{vue,js,ts}',
+    './components/**/*.{vue,js,ts}',
+    './layouts/**/*.{vue,js,ts}',
+    './pages/**/*.{vue,js,ts}',
+    './plugins/**/*.{js,ts}',
+    './server/**/*.{js,ts}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'var(--color-background)',
+        foreground: 'var(--color-foreground)',
+        accent: 'var(--accent-color)',
+        muted: 'var(--color-muted)',
+        border: 'var(--color-border)',
+      },
+      spacing: {
+        xs: 'var(--space-xs)',
+        sm: 'var(--space-sm)',
+        md: 'var(--space-md)',
+        lg: 'var(--space-lg)',
+        xl: 'var(--space-xl)',
+      },
+      borderRadius: {
+        none: 'var(--radius-none)',
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        full: 'var(--radius-full)',
+      },
+      fontSize: {
+        xs: ['var(--font-size-xs)', 'var(--line-height-xs)'],
+        sm: ['var(--font-size-sm)', 'var(--line-height-sm)'],
+        base: ['var(--font-size-base)', 'var(--line-height-base)'],
+        lg: ['var(--font-size-lg)', 'var(--line-height-lg)'],
+        xl: ['var(--font-size-xl)', 'var(--line-height-xl)'],
+      },
+      fontFamily: {
+        sans: 'var(--font-family-sans)',
+        serif: 'var(--font-family-serif)',
+        mono: 'var(--font-family-mono)',
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add the Tailwind CSS entry file with Flowbite plugin directives and sources
- register the Flowbite Vue plugin and extend Tailwind with CSS variable-driven tokens
- configure Nuxt and PostCSS to load the shared Tailwind stylesheet

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d633112d88832fa06197f5444e2575