### PR TITLE
Fix Tailwind Flowbite integration

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,9 +1,3 @@
-@import "tailwindcss";
-@plugin "flowbite/plugin";
-@source "./components";
-@source "./pages";
-@source "./layouts";
-@source "./app.vue";
-@source "./error.vue";
-@source "../node_modules/flowbite";
-@source "../node_modules/flowbite-vue";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import flowbitePlugin from 'flowbite/plugin';
+
 export default {
   content: [
     './app.vue',
@@ -9,6 +11,8 @@ export default {
     './pages/**/*.{vue,js,ts}',
     './plugins/**/*.{js,ts}',
     './server/**/*.{js,ts}',
+    './node_modules/flowbite/**/*.{js,ts}',
+    './node_modules/flowbite-vue/**/*.{js,ts,vue}',
   ],
   theme: {
     extend: {
@@ -47,5 +51,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [flowbitePlugin],
 };


### PR DESCRIPTION
## Summary
- register the Flowbite plugin via the Tailwind configuration and scan Flowbite packages for class usage
- simplify the Tailwind CSS entry file to rely on standard Tailwind layers to avoid esbuild minifier warnings

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d636666194832fb56d1522bdd8408c