### PR TITLE
Fix Tailwind source paths for Nuxt build

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -1,10 +1,13 @@
 @import "tailwindcss";
 @plugin "flowbite/plugin";
 
-@source "./components";
-@source "./pages";
-@source "./layouts";
-@source "./app.vue";
-@source "./error.vue";
-@source "../node_modules/flowbite";
-@source "../node_modules/flowbite-vue";
+@source "../../app.vue";
+@source "../../error.vue";
+@source "../../app";
+@source "../../components";
+@source "../../layouts";
+@source "../../pages";
+@source "../../plugins";
+@source "../../server";
+@source "../../node_modules/flowbite";
+@source "../../node_modules/flowbite-vue";


### PR DESCRIPTION
## Summary
- correct Tailwind CSS @source paths to reference Nuxt directories from assets/css
- ensure Flowbite sources resolve from the project node_modules directory

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d65082241c832f852c808b08bd5c1b