### PR TITLE
Fix Tailwind 4 integration by dynamically loading the Vite plugin

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,3 @@
-import tailwindcss from '@tailwindcss/vite'
-
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   srcDir: '.',
@@ -18,8 +16,16 @@ export default defineNuxtConfig({
       }
     ]
   },
+  hooks: {
+    'vite:extendConfig': async (config) => {
+      // Chargement dynamique : le paquet @tailwindcss/vite n'expose qu'une entrée ESM,
+      // ce qui casse l'import statique pendant le chargement CJS du nuxt.config.
+      const { default: tailwindcss } = await import('@tailwindcss/vite')
+      config.plugins = config.plugins || []
+      config.plugins.push(tailwindcss())
+    }
+  },
   vite: {
-    plugins: [tailwindcss()],
     ssr: {
       noExternal: ['flowbite-vue']
     }


### PR DESCRIPTION
## Summary
- load the @tailwindcss/vite plugin through a Nuxt hook to prevent CJS import errors and enable Tailwind processing

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68d65dbb2180832fb0e095e35c46254e