### PR TITLE
Expose active theme tokens via API and add manifest metadata

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,8 @@
+{
+  "ssr": true,
+  "cache": "default",
+  "seo": {
+    "canonical": true,
+    "hreflang": true
+  }
+}

--- a/server/api/theme.get.ts
+++ b/server/api/theme.get.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { DEFAULT_TENANT, loadTokens } from '../utils/theme'
+import { DEFAULT_TENANT, loadTokens, tokensToCssVars } from '../utils/theme'
 
 export default defineEventHandler(async (event) => {
   const contextTenant = event.context.tenant
@@ -9,6 +9,7 @@ export default defineEventHandler(async (event) => {
       id: contextTenant.id,
       theme: contextTenant.theme,
       tokens: contextTenant.tokens,
+      css: contextTenant.css ?? tokensToCssVars(contextTenant.tokens),
       darkEnabled: Boolean(contextTenant.tokens?.dark?.enabled)
     }
   }
@@ -20,6 +21,7 @@ export default defineEventHandler(async (event) => {
     id: DEFAULT_TENANT,
     theme: fallbackTheme,
     tokens: fallbackTokens,
+    css: tokensToCssVars(fallbackTokens),
     darkEnabled: Boolean(fallbackTokens.dark?.enabled)
   }
 })


### PR DESCRIPTION
## Summary
- ensure the theme API returns the active tenant tokens along with CSS fallbacks
- add a placeholder manifest.json with SSR, cache, and SEO flags

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d665ceaaf0832fbf76bce740264a05